### PR TITLE
Fix deploy message formatting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,4 +91,4 @@ deploy:
   type: git
   repo: git@github.com:wangzhe/wangzhe.github.io.git
   branch: master
-  message: "Jack's House updated: {{ now('YYYY-MM-DD HH:mm:ss') }})"
+  message: "Jack's House updated: {{ now('YYYY-MM-DD HH:mm:ss') }}"


### PR DESCRIPTION
## Summary
- fix deploy commit message syntax in Hexo config

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_687f1d6e3a908330bdb6a9004280beef