### PR TITLE
Fix hexo-cli dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "hexo": "^5.0.0",
-        "hexo-cli": "hexojs/hexo-cli",
+        "hexo-cli": "^4.2.0",
         "hexo-deployer-git": "^2.1.0",
         "hexo-generator-archive": "^1.0.0",
         "hexo-generator-category": "^1.0.0",
@@ -1501,7 +1501,7 @@
     },
     "node_modules/hexo-cli": {
       "version": "4.2.0",
-      "resolved": "git+ssh://git@github.com/hexojs/hexo-cli.git#5f29f5a0aa414e3226e4d820b49b87a931169832",
+      "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-4.2.0.tgz",
       "license": "MIT",
       "dependencies": {
         "abbrev": "^1.1.1",
@@ -5720,8 +5720,9 @@
       }
     },
     "hexo-cli": {
-      "version": "git+ssh://git@github.com/hexojs/hexo-cli.git#5f29f5a0aa414e3226e4d820b49b87a931169832",
-      "from": "hexo-cli@hexojs/hexo-cli",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-4.2.0.tgz",
+      "from": "hexo-cli@^4.2.0",
       "requires": {
         "abbrev": "^1.1.1",
         "bluebird": "^3.5.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "hexo": "^5.0.0",
-    "hexo-cli": "hexojs/hexo-cli",
+    "hexo-cli": "^4.2.0",
     "hexo-deployer-git": "^2.1.0",
     "hexo-generator-archive": "^1.0.0",
     "hexo-generator-category": "^1.0.0",


### PR DESCRIPTION
## Summary
- use a released version for `hexo-cli`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f1e044e9c83308dad6b4cc61a36c3